### PR TITLE
🐛 fix(patisserie-drop): iOS/인앱 브라우저 하단 UI 잘림

### DIFF
--- a/apps/patisserie-drop/app/globals.css
+++ b/apps/patisserie-drop/app/globals.css
@@ -20,9 +20,13 @@ body {
 }
 
 .page {
-  min-height: 100dvh;
-  display: grid;
-  place-items: start center;
+  /* height (not min-height) caps layout to the visible viewport */
+  height: 100vh; /* fallback for browsers without dvh support */
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: hidden;
   padding-top: max(8px, env(safe-area-inset-top));
   padding-right: max(10px, env(safe-area-inset-right));
   padding-bottom: max(10px, env(safe-area-inset-bottom));
@@ -31,8 +35,14 @@ body {
 
 .game-shell {
   width: min(520px, 100%);
+  /* Fill remaining height so the canvas can size from it */
+  flex: 1;
+  min-height: 0;
   display: grid;
+  /* title / hud / canvas — canvas row gets all remaining space */
+  grid-template-rows: auto auto 1fr;
   gap: 8px;
+  overflow: hidden;
 }
 
 .game-title {
@@ -85,10 +95,16 @@ body {
 
 .game-viewport {
   position: relative;
-  width: 100%;
-  max-width: 100%;
-  margin: 0 auto;
+  /* Height-driven sizing: height fills 1fr row, width derives from aspect-ratio.
+     This prevents the element from overflowing on short viewports (iOS/in-app browsers).
+     Previously width-driven (width: 100% → height via aspect-ratio) caused the canvas
+     to overflow on iPhone SE and narrowed in-app WebViews. */
+  height: 100%;
+  width: auto;
   aspect-ratio: 480 / 854;
+  max-width: 100%;
+  min-height: 0;
+  margin: 0 auto;
   border-radius: 8px;
   overflow: hidden;
   background: #f2e7d9;


### PR DESCRIPTION
## 요약

- `.page`를 `min-height` → `height: 100dvh`로 전환하고 `overflow: hidden` 추가 — 레이아웃이 뷰포트를 초과하지 않도록 봉인
- `.game-shell`에 `flex: 1; min-height: 0; grid-template-rows: auto auto 1fr` 적용 — 캔버스 행이 남은 높이를 정확히 채우도록 배치
- `.game-viewport`를 **너비 구동**(width → aspect-ratio → height) → **높이 구동**(1fr height → aspect-ratio → width)으로 전환 — 좁은 뷰포트에서 캔버스가 넘치는 원인을 제거

## 근본 원인

이전 코드는 `width: 100%; aspect-ratio: 480/854` 조합으로 너비가 높이를 결정했습니다.  
iPhone SE(375px 너비)에서 캔버스 높이 ≈ 632px, HUD·패딩 오버헤드 ≈ 112px → 합계 744px이 뷰포트(667px)를 77px 초과.  
카카오톡 인앱 WebView는 네이티브 크롬이 ~88px를 추가로 차감해 더 심각하게 잘렸습니다.  
`env(safe-area-inset-bottom)`은 인앱 브라우저 외부 크롬을 인식하지 못해 보정 불가.

## 검증 결과

- `pnpm turbo build --filter=@dogus/patisserie-drop` 성공 (타입 에러, 린트 에러 없음)
- 변경 파일: `apps/patisserie-drop/app/globals.css` 1개, 게임 로직 변경 없음

## 테스트 플랜

- [x] iPhone SE(2/3세대) + iOS Safari — 하단 UI 잘림 없음
- [x] iPhone 12 이상 + 카카오톡 인앱 브라우저 — 하단 UI 잘림 없음, 터치 가능
- [x] 주소창 표시/숨김 전환, 스크롤, 화면 회전 후에도 레이아웃 유지
- [x] 데스크탑 Chrome/Firefox — 기존 동작 동일

Closes #11