### PR TITLE
✨ feat(patisserie-drop): 충돌 영역 시각화 hitCircle 추가

### DIFF
--- a/apps/patisserie-drop/game/core/model/levels.ts
+++ b/apps/patisserie-drop/game/core/model/levels.ts
@@ -2,30 +2,14 @@ export interface LevelDefinition {
   level: number;
   radius: number;
   label: string;
-  hitColor: number;
 }
 
 const LEVEL_RADII = [18, 24, 32, 42, 55, 73, 96, 127, 168, 221, 295] as const;
-
-const LEVEL_HIT_COLORS = [
-  0xf5d99a, // Lv1  밝은 황금
-  0xedc87a, // Lv2  황색
-  0xf0d0a0, // Lv3  연한 크림
-  0xe8a87a, // Lv4  살구
-  0xd4886a, // Lv5  연어색
-  0xc07050, // Lv6  중간 브라운
-  0xa85840, // Lv7  붉은 브라운
-  0x905048, // Lv8  다크 브라운
-  0x784060, // Lv9  딥 퍼플
-  0xb84878, // Lv10 딸기 핑크
-  0xd4609a, // Lv11 밝은 핑크
-] as const;
 
 export const LEVEL_DEFINITIONS: LevelDefinition[] = LEVEL_RADII.map((radius, index) => ({
   level: index + 1,
   radius,
   label: `Lv${index + 1}`,
-  hitColor: LEVEL_HIT_COLORS[index],
 }));
 
 export const MIN_LEVEL = 1;

--- a/apps/patisserie-drop/game/core/model/levels.ts
+++ b/apps/patisserie-drop/game/core/model/levels.ts
@@ -2,14 +2,30 @@ export interface LevelDefinition {
   level: number;
   radius: number;
   label: string;
+  hitColor: number;
 }
 
 const LEVEL_RADII = [18, 24, 32, 42, 55, 73, 96, 127, 168, 221, 295] as const;
+
+const LEVEL_HIT_COLORS = [
+  0xf5d99a, // Lv1  밝은 황금
+  0xedc87a, // Lv2  황색
+  0xf0d0a0, // Lv3  연한 크림
+  0xe8a87a, // Lv4  살구
+  0xd4886a, // Lv5  연어색
+  0xc07050, // Lv6  중간 브라운
+  0xa85840, // Lv7  붉은 브라운
+  0x905048, // Lv8  다크 브라운
+  0x784060, // Lv9  딥 퍼플
+  0xb84878, // Lv10 딸기 핑크
+  0xd4609a, // Lv11 밝은 핑크
+] as const;
 
 export const LEVEL_DEFINITIONS: LevelDefinition[] = LEVEL_RADII.map((radius, index) => ({
   level: index + 1,
   radius,
   label: `Lv${index + 1}`,
+  hitColor: LEVEL_HIT_COLORS[index],
 }));
 
 export const MIN_LEVEL = 1;

--- a/apps/patisserie-drop/game/runtime/scene.ts
+++ b/apps/patisserie-drop/game/runtime/scene.ts
@@ -36,6 +36,7 @@ interface BallEntity {
   radius: number;
   body: MatterJS.BodyType;
   display: Phaser.GameObjects.Image;
+  hitCircle: Phaser.GameObjects.Arc;
 }
 
 function spriteKey(level: number): string {
@@ -259,6 +260,7 @@ export class PatisserieDropScene extends Phaser.Scene {
   private clearRoundObjects(): void {
     this.balls.forEach((ball) => {
       this.matter.world.remove(ball.body);
+      ball.hitCircle.destroy();
       ball.display.destroy();
     });
 
@@ -345,7 +347,7 @@ export class PatisserieDropScene extends Phaser.Scene {
   }
 
   private addBall(level: number, x: number, y: number): BallEntity {
-    const { radius } = getLevelDefinition(level);
+    const { radius, hitColor } = getLevelDefinition(level);
     const id = ++this.ballIdCounter;
 
     const body = this.matter.add.circle(x, y, radius, {
@@ -355,6 +357,12 @@ export class PatisserieDropScene extends Phaser.Scene {
       restitution: PHYSICS_RESTITUTION,
       density: level * PHYSICS_DENSITY_FACTOR
     });
+
+    const hitCircle = this.add
+      .arc(x, y, radius)
+      .setFillStyle(hitColor, 0.18)
+      .setStrokeStyle(1.5, hitColor, 0.45)
+      .setDepth(4);
 
     const displaySize = radius * 2 * SPRITE_DISPLAY_SCALE;
     const display = this.add
@@ -367,6 +375,7 @@ export class PatisserieDropScene extends Phaser.Scene {
       level,
       radius,
       body,
+      hitCircle,
       display
     };
 
@@ -378,7 +387,9 @@ export class PatisserieDropScene extends Phaser.Scene {
 
   private syncDisplayObjects(): void {
     this.balls.forEach((entity) => {
-      entity.display.setPosition(entity.body.position.x, entity.body.position.y);
+      const { x, y } = entity.body.position;
+      entity.hitCircle.setPosition(x, y);
+      entity.display.setPosition(x, y);
       entity.display.setRotation(entity.body.angle);
     });
   }
@@ -464,6 +475,7 @@ export class PatisserieDropScene extends Phaser.Scene {
     this.matter.world.remove(ball.body);
     this.bodyToBall.delete(ball.body.id);
     this.balls.delete(ball.id);
+    ball.hitCircle.destroy();
     ball.display.destroy();
   }
 

--- a/apps/patisserie-drop/game/runtime/scene.ts
+++ b/apps/patisserie-drop/game/runtime/scene.ts
@@ -39,6 +39,8 @@ interface BallEntity {
   hitCircle: Phaser.GameObjects.Arc;
 }
 
+const HIT_CIRCLE_COLOR = 0xd4886a; // Lv5 연어색 — 임시 단일 색상
+
 function spriteKey(level: number): string {
   return `item-lv${String(level).padStart(2, "0")}`;
 }
@@ -347,7 +349,7 @@ export class PatisserieDropScene extends Phaser.Scene {
   }
 
   private addBall(level: number, x: number, y: number): BallEntity {
-    const { radius, hitColor } = getLevelDefinition(level);
+    const { radius } = getLevelDefinition(level);
     const id = ++this.ballIdCounter;
 
     const body = this.matter.add.circle(x, y, radius, {
@@ -360,8 +362,8 @@ export class PatisserieDropScene extends Phaser.Scene {
 
     const hitCircle = this.add
       .arc(x, y, radius)
-      .setFillStyle(hitColor, 0.18)
-      .setStrokeStyle(1.5, hitColor, 0.45)
+      .setFillStyle(HIT_CIRCLE_COLOR, 0.18)
+      .setStrokeStyle(1.5, HIT_CIRCLE_COLOR, 0.45)
       .setDepth(4);
 
     const displaySize = radius * 2 * SPRITE_DISPLAY_SCALE;


### PR DESCRIPTION
## Summary
- 각 볼의 Matter.js body radius와 동일한 크기의 반투명 원(hitCircle)을 스프라이트 아래 레이어(depth 4)에 상시 표시
- 색상은 Lv5 연어색(`0xd4886a`) 단일 상수로 통일 (임시 UX 기능)

## Related Issue
Closes #14

## Spec-Driven Artifacts
- 이 PR은 Issue #14 승인을 Spec/Plan으로 대체하는 단순 UX 기능입니다 (spec 파일 없음).

## Reviewer Quick View
- Primary packages/apps touched: `apps/patisserie-drop`
- User-visible behavior changes: 드롭된 볼에 반투명 원이 표시됨
- New or changed public interfaces: 없음
- Breaking change: No

## Interface & Contract Changes
- Added: `BallEntity.hitCircle: Phaser.GameObjects.Arc`, `HIT_CIRCLE_COLOR` 상수
- Modified: `addBall()`, `syncDisplayObjects()`, `removeBall()`, `clearRoundObjects()`
- Removed: 없음
- Migration needed: No

## Verification Log
- [x] `pnpm turbo build` — `✓ Compiled successfully`, 타입 에러 0
- [x] Local smoke checks completed

### Key Output (only critical lines)
```
@dogus/patisserie-drop:build:  ✓ Compiled successfully in 889ms
@dogus/patisserie-drop:build:  ✓ Generating static pages (4/4)
Tasks: 1 successful, 1 total
```

## Post-Merge Production Check (same issue, no separate issue)
- Record location: Issue #14 comment
- Result: 머지 후 Vercel Preview에서 확인 예정

## Risks / Follow-ups (for human decision)
- 남은 위험: 없음
- Follow-up: 스프라이트 색상 확정 후 `HIT_CIRCLE_COLOR` 팔레트 전환 가능 (별도 이슈)

## Review Checklist
- [x] Branch name follows `issues/<number>-<type>-<description>`
- [x] Scope matches related issue and approved artifacts
- [x] `.agent` and `docs` updates are included when required
- [x] No unrelated changes included